### PR TITLE
Refactor pages into hooks

### DIFF
--- a/src/hooks/useJoinFlow.ts
+++ b/src/hooks/useJoinFlow.ts
@@ -1,0 +1,271 @@
+import { useState, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { LottieRefCurrentProps } from "lottie-react";
+import { teamService, participantService } from '../api';
+import useTypingText from './useTypingText';
+import useJoinQuestions from './useJoinQuestions';
+import { Team } from '../features/teams/types';
+import { Participant, ParticipantCreate } from '../features/participants/types';
+
+const useJoinFlow = () => {
+  const navigate = useNavigate();
+  const [step, setStep] = useState(1);
+  const [name, setName] = useState('');
+  const [selections, setSelections] = useState<string[]>([]);
+  const { text: displayText, start: startTyping } = useTypingText();
+  const { getQuestionText, getOptions } = useJoinQuestions(name, selections);
+  const [isLoading, setIsLoading] = useState(false);
+  const [showSpark, setShowSpark] = useState(false);
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
+  const [isTeamsLoaded, setIsTeamsLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isChecking, setIsChecking] = useState(false);
+  const currentStepRef = useRef<number>(1);
+  const congratsRef = useRef<LottieRefCurrentProps>(null);
+
+  useEffect(() => {
+    const savedParticipantId = localStorage.getItem('participantId');
+    if (savedParticipantId) {
+      checkSavedParticipant(savedParticipantId);
+    }
+  }, []);
+
+  const checkSavedParticipant = async (participantId: string) => {
+    try {
+      const participant = await participantService.getById(participantId);
+      if (participant) {
+        saveParticipantToLocalStorage(participant);
+        navigate('/main');
+      }
+    } catch (error) {
+      console.error('저장된 참가자 정보 확인 실패:', error);
+      localStorage.removeItem('participantId');
+    }
+  };
+
+  useEffect(() => {
+    const fetchTeams = async () => {
+      try {
+        const teamsData = await teamService.getByBatch(1);
+        if (teamsData && teamsData.length > 0) {
+          setTeams(teamsData);
+          setIsTeamsLoaded(true);
+        } else {
+          console.error('팀 데이터가 없습니다.');
+        }
+      } catch (error) {
+        console.error('팀 데이터 로딩 중 오류 발생:', error);
+      }
+    };
+
+    fetchTeams();
+  }, []);
+
+  const checkNameExists = async (name: string) => {
+    if (!name.trim()) return false;
+
+    try {
+      setIsChecking(true);
+      const participants = await participantService.getByName(name.trim());
+      setIsChecking(false);
+
+      if (participants && participants.length > 0) {
+        saveParticipantToLocalStorage(participants[0]);
+        navigate('/main');
+        return true;
+      }
+      return false;
+    } catch (error) {
+      console.error('이름 중복 확인 중 오류 발생:', error);
+      setIsChecking(false);
+      return false;
+    }
+  };
+
+  const saveParticipantToLocalStorage = (participant: Participant) => {
+    localStorage.setItem('participantId', participant.id);
+    localStorage.setItem('participantName', participant.name);
+    localStorage.setItem('participantTeam', participant.team);
+    localStorage.setItem('participantRole', participant.role);
+    localStorage.setItem('participantBatch', participant.batch.toString());
+  };
+
+  const handleNext = () => {
+    if (step === 3) {
+      setIsLoading(true);
+
+      setTimeout(() => {
+        setShowSpark(true);
+
+        setTimeout(() => {
+          setShowSpark(false);
+          setIsLoading(false);
+          const nextStep = step + 1;
+          currentStepRef.current = nextStep;
+          setStep(nextStep);
+
+          setTimeout(() => {
+            startTypingAnimation();
+          }, 100);
+        }, 500);
+      }, 5000);
+
+      return;
+    }
+
+    const nextStep = step + 1;
+    currentStepRef.current = nextStep;
+    setStep(nextStep);
+
+    setTimeout(() => {
+      startTypingAnimation();
+    }, 100);
+  };
+
+  const selectLeastPopulatedTeam = async () => {
+    try {
+      if (!isTeamsLoaded || teams.length === 0) {
+        console.error('팀 데이터가 로드되지 않았습니다.');
+        return null;
+      }
+
+      const teamCounts = await participantService.getTeamCounts(1);
+      if (!teamCounts) {
+        console.error('팀별 참가자 수를 가져오는 데 실패했습니다.');
+        return teams[Math.floor(Math.random() * teams.length)];
+      }
+
+      const teamsWithCounts = teams.map(team => ({
+        ...team,
+        count: teamCounts[team.name] || 0,
+      }));
+
+      const minCount = Math.min(...teamsWithCounts.map(t => t.count));
+      const leastPopulatedTeams = teamsWithCounts.filter(t => t.count === minCount);
+
+      const selectedTeam =
+        leastPopulatedTeams[Math.floor(Math.random() * leastPopulatedTeams.length)];
+
+      return selectedTeam;
+    } catch (error) {
+      console.error('팀 선택 중 오류 발생:', error);
+      return teams[Math.floor(Math.random() * teams.length)];
+    }
+  };
+
+  const createParticipant = async (team: Team) => {
+    try {
+      if (!name.trim()) {
+        console.error('참가자 이름이 없습니다.');
+        return false;
+      }
+
+      const newParticipant: ParticipantCreate = {
+        name: name.trim(),
+        team: team.name,
+        role: '참가자',
+        batch: 1,
+      };
+
+      const result = await participantService.create(newParticipant);
+      if (result && result.length > 0) {
+        saveParticipantToLocalStorage(result[0]);
+        return true;
+      } else {
+        console.error('참가자 생성 실패');
+        return false;
+      }
+    } catch (error) {
+      console.error('참가자 생성 중 오류 발생:', error);
+      return false;
+    }
+  };
+
+  const handleSelection = (option: string) => {
+    setSelections(prev => [...prev, option]);
+
+    if (step === 3) {
+      if (isTeamsLoaded && teams.length > 0) {
+        selectLeastPopulatedTeam().then(team => {
+          if (team) {
+            setSelectedTeam(team);
+            createParticipant(team).then(success => {
+              if (!success) {
+                setError('참가자 정보를 저장하는데 실패했습니다.');
+              }
+            });
+          } else {
+            console.error('팀 선택에 실패했습니다.');
+          }
+        });
+      } else {
+        console.error('팀 데이터가 로드되지 않았습니다.');
+      }
+    }
+
+    handleNext();
+  };
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setName(e.target.value);
+  };
+
+  const handleNameSubmit = async () => {
+    if (!name.trim()) return;
+
+    const nameExists = await checkNameExists(name);
+
+    if (!nameExists) {
+      handleNext();
+    }
+  };
+
+  const startTypingAnimation = () => {
+    startTyping(getQuestionText(currentStepRef.current));
+  };
+
+  useEffect(() => {
+    currentStepRef.current = step;
+  }, [step]);
+
+  useEffect(() => {
+    startTypingAnimation();
+  }, []);
+
+  useEffect(() => {
+    if (step === 2) {
+      startTypingAnimation();
+    }
+  }, [name, step]);
+
+  useEffect(() => {
+    if (congratsRef.current) {
+      congratsRef.current.setSpeed(0.5);
+    }
+  }, [step]);
+
+  const handleCompleteClick = () => {
+    navigate('/main');
+  };
+
+  return {
+    step,
+    name,
+    selections,
+    displayText,
+    getOptions,
+    isLoading,
+    showSpark,
+    selectedTeam,
+    error,
+    isChecking,
+    congratsRef,
+    handleNameChange,
+    handleNameSubmit,
+    handleSelection,
+    handleCompleteClick,
+  };
+};
+
+export default useJoinFlow;

--- a/src/hooks/useMainData.ts
+++ b/src/hooks/useMainData.ts
@@ -1,0 +1,82 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { teamService, participantService } from '../api';
+import { Team } from '../features/teams/types';
+import { Participant } from '../features/participants/types';
+
+const useMainData = () => {
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [team, setTeam] = useState<Team | null>(null);
+  const [teamMembers, setTeamMembers] = useState<Participant[]>([]);
+  const [currentParticipant, setCurrentParticipant] =
+    useState<Participant | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const participantId = localStorage.getItem('participantId');
+        const participantTeam = localStorage.getItem('participantTeam');
+
+        if (!participantId || !participantTeam) {
+          navigate('/join');
+          return;
+        }
+
+        const participant = await participantService.getById(participantId);
+        if (!participant) {
+          throw new Error('참가자 정보를 찾을 수 없습니다.');
+        }
+        setCurrentParticipant(participant);
+
+        const teams = await teamService.getByName(participantTeam);
+        if (!teams) {
+          throw new Error('팀 정보를 찾을 수 없습니다.');
+        }
+        setTeam(teams);
+
+        const batch = participant.batch;
+        const allParticipants = await participantService.getByBatch(batch);
+        if (allParticipants) {
+          const sameTeamMembers = allParticipants.filter(
+            p => p.team === participantTeam,
+          );
+          setTeamMembers(sameTeamMembers);
+        }
+
+        setLoading(false);
+      } catch (err) {
+        console.error('데이터 로딩 중 오류 발생:', err);
+        setError(
+          err instanceof Error
+            ? err.message
+            : '데이터를 불러오는 중 오류가 발생했습니다.',
+        );
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [navigate]);
+
+  const handleLeaveTeam = () => {
+    localStorage.removeItem('participantId');
+    localStorage.removeItem('participantName');
+    localStorage.removeItem('participantTeam');
+    localStorage.removeItem('participantRole');
+    localStorage.removeItem('participantBatch');
+    navigate('/');
+  };
+
+  return {
+    loading,
+    error,
+    team,
+    teamMembers,
+    currentParticipant,
+    handleLeaveTeam,
+  };
+};
+
+export default useMainData;

--- a/src/hooks/useSettingManager.ts
+++ b/src/hooks/useSettingManager.ts
@@ -435,6 +435,7 @@ const useSettingManager = () => {
     setError,
     setSuccess,
     handleGoHome,
+    setTeamForm,
   };
 };
 

--- a/src/hooks/useSettingManager.ts
+++ b/src/hooks/useSettingManager.ts
@@ -1,0 +1,441 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { participantService, teamService, storageService } from '../api';
+import { Participant, ParticipantCreate } from '../features/participants/types';
+import { Team, TeamCreate } from '../features/teams/types';
+
+export enum Tab {
+  TEAMS = 'teams',
+  PARTICIPANTS = 'participants',
+}
+
+export enum Mode {
+  LIST = 'list',
+  CREATE = 'create',
+  EDIT = 'edit',
+}
+
+const useSettingManager = () => {
+  const navigate = useNavigate();
+  const [tab, setTab] = useState<Tab>(Tab.TEAMS);
+  const [mode, setMode] = useState<Mode>(Mode.LIST);
+  const [batch, setBatch] = useState<number>(1);
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [participants, setParticipants] = useState<Participant[]>([]);
+  const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
+  const [selectedParticipant, setSelectedParticipant] = useState<Participant | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [teamFilter, setTeamFilter] = useState<string>('전체');
+
+  const [teamForm, setTeamForm] = useState<Partial<TeamCreate>>({
+    name: '',
+    description: '',
+    characteristic: '',
+    image_url: '',
+    is_active: true,
+    batch: 1,
+  });
+
+  const [participantForm, setParticipantForm] = useState<Partial<ParticipantCreate>>({
+    name: '',
+    team: '',
+    role: '',
+    batch: 1,
+  });
+
+  const [teamImage, setTeamImage] = useState<File | null>(null);
+
+  useEffect(() => {
+    fetchTeams();
+    fetchParticipants();
+  }, [batch]);
+
+  const fetchTeams = async () => {
+    try {
+      setLoading(true);
+
+      const result = await teamService.getAllByBatch(batch);
+      if (result) {
+        setTeams(result);
+      } else {
+        setError('팀 데이터를 불러오는데 실패했습니다.');
+      }
+    } catch (err) {
+      setError('오류가 발생했습니다.');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchParticipants = async () => {
+    try {
+      setLoading(true);
+      const result = await participantService.getByBatch(batch);
+      if (result) {
+        setParticipants(result);
+      } else {
+        setError('참가자 데이터를 불러오는데 실패했습니다.');
+      }
+    } catch (err) {
+      setError('오류가 발생했습니다.');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const filteredParticipants =
+    teamFilter === '전체' ? participants : participants.filter(p => p.team === teamFilter);
+
+  const handleCreateTeam = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      setLoading(true);
+      setError(null);
+
+      let imageUrl = teamForm.image_url;
+
+      if (teamImage) {
+        const path = `teams/${Date.now()}_${teamImage.name}`;
+        const uploadedUrl = await storageService.uploadImage(teamImage, path);
+        if (uploadedUrl) {
+          imageUrl = uploadedUrl;
+        } else {
+          setError('이미지 업로드에 실패했습니다.');
+          setLoading(false);
+          return;
+        }
+      }
+
+      const newTeam: TeamCreate = {
+        name: teamForm.name || '',
+        description: teamForm.description || '',
+        characteristic: teamForm.characteristic || '',
+        image_url: imageUrl || '',
+        is_active: teamForm.is_active !== undefined ? teamForm.is_active : true,
+        batch: teamForm.batch || batch,
+      };
+
+      const result = await teamService.create(newTeam);
+      if (result) {
+        setSuccess('팀이 성공적으로 생성되었습니다.');
+        setMode(Mode.LIST);
+        fetchTeams();
+        resetTeamForm();
+      } else {
+        setError('팀 생성에 실패했습니다.');
+      }
+    } catch (err) {
+      setError('오류가 발생했습니다.');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleUpdateTeam = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedTeam) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      let imageUrl = teamForm.image_url;
+
+      if (teamImage) {
+        const path = `teams/${Date.now()}_${teamImage.name}`;
+        const uploadedUrl = await storageService.uploadImage(teamImage, path);
+        if (uploadedUrl) {
+          imageUrl = uploadedUrl;
+        } else {
+          setError('이미지 업로드에 실패했습니다.');
+          setLoading(false);
+          return;
+        }
+      }
+
+      const updatedTeam: Partial<TeamCreate> = {
+        name: teamForm.name,
+        description: teamForm.description,
+        characteristic: teamForm.characteristic,
+        is_active: teamForm.is_active,
+        batch: teamForm.batch,
+      };
+
+      if (imageUrl && imageUrl !== selectedTeam.image_url) {
+        updatedTeam.image_url = imageUrl;
+      }
+
+      const result = await teamService.update(selectedTeam.id, updatedTeam);
+      if (result) {
+        setSuccess('팀이 성공적으로 수정되었습니다.');
+        setMode(Mode.LIST);
+        fetchTeams();
+        resetTeamForm();
+      } else {
+        setError('팀 수정에 실패했습니다.');
+      }
+    } catch (err) {
+      setError('오류가 발생했습니다.');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDeleteTeam = async (id: string) => {
+    if (!window.confirm('정말로 이 팀을 삭제하시겠습니까?')) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      const success = await teamService.delete(id);
+      if (success) {
+        setSuccess('팀이 성공적으로 삭제되었습니다.');
+        fetchTeams();
+      } else {
+        setError('팀 삭제에 실패했습니다.');
+      }
+    } catch (err) {
+      setError('오류가 발생했습니다.');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCreateParticipant = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      setLoading(true);
+      setError(null);
+
+      const newParticipant: ParticipantCreate = {
+        name: participantForm.name || '',
+        team: participantForm.team || '',
+        role: participantForm.role || '',
+        batch: participantForm.batch || batch,
+      };
+
+      const result = await participantService.create(newParticipant);
+      if (result) {
+        setSuccess('참가자가 성공적으로 생성되었습니다.');
+        setMode(Mode.LIST);
+        fetchParticipants();
+        resetParticipantForm();
+      } else {
+        setError('참가자 생성에 실패했습니다.');
+      }
+    } catch (err) {
+      setError('오류가 발생했습니다.');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleUpdateParticipant = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedParticipant) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      const updatedParticipant: Partial<ParticipantCreate> = {
+        name: participantForm.name,
+        team: participantForm.team,
+        role: participantForm.role,
+        batch: participantForm.batch,
+      };
+
+      const result = await participantService.update(selectedParticipant.id, updatedParticipant);
+      if (result) {
+        setSuccess('참가자가 성공적으로 수정되었습니다.');
+        setMode(Mode.LIST);
+        fetchParticipants();
+        resetParticipantForm();
+      } else {
+        setError('참가자 수정에 실패했습니다.');
+      }
+    } catch (err) {
+      setError('오류가 발생했습니다.');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDeleteParticipant = async (id: string) => {
+    if (!window.confirm('정말로 이 참가자를 삭제하시겠습니까?')) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      const success = await participantService.delete(id);
+      if (success) {
+        setSuccess('참가자가 성공적으로 삭제되었습니다.');
+        fetchParticipants();
+      } else {
+        setError('참가자 삭제에 실패했습니다.');
+      }
+    } catch (err) {
+      setError('오류가 발생했습니다.');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleEditTeam = (team: Team) => {
+    setSelectedTeam(team);
+    setTeamForm({
+      name: team.name,
+      description: team.description,
+      characteristic: team.characteristic,
+      image_url: team.image_url,
+      is_active: team.is_active,
+      batch: team.batch,
+    });
+    setMode(Mode.EDIT);
+  };
+
+  const handleEditParticipant = (participant: Participant) => {
+    setSelectedParticipant(participant);
+    setParticipantForm({
+      name: participant.name,
+      team: participant.team,
+      role: participant.role,
+      batch: participant.batch,
+    });
+    setMode(Mode.EDIT);
+  };
+
+  const handleTeamFormChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+  ) => {
+    const { name, value, type } = e.target;
+    if (type === 'checkbox') {
+      const checked = (e.target as HTMLInputElement).checked;
+      setTeamForm(prev => ({ ...prev, [name]: checked }));
+    } else if (name === 'batch') {
+      setTeamForm(prev => ({ ...prev, [name]: parseInt(value) }));
+    } else {
+      setTeamForm(prev => ({ ...prev, [name]: value }));
+    }
+  };
+
+  const handleParticipantFormChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+  ) => {
+    const { name, value } = e.target;
+    if (name === 'batch') {
+      setParticipantForm(prev => ({ ...prev, [name]: parseInt(value) }));
+    } else {
+      setParticipantForm(prev => ({ ...prev, [name]: value }));
+    }
+  };
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      setTeamImage(e.target.files[0]);
+    }
+  };
+
+  const resetTeamForm = () => {
+    setTeamForm({
+      name: '',
+      description: '',
+      characteristic: '',
+      image_url: '',
+      is_active: true,
+      batch: batch,
+    });
+    setTeamImage(null);
+    setSelectedTeam(null);
+  };
+
+  const resetParticipantForm = () => {
+    setParticipantForm({
+      name: '',
+      team: '',
+      role: '',
+      batch: batch,
+    });
+    setSelectedParticipant(null);
+  };
+
+  const startCreateMode = () => {
+    if (tab === Tab.TEAMS) {
+      resetTeamForm();
+    } else {
+      resetParticipantForm();
+    }
+    setMode(Mode.CREATE);
+  };
+
+  const handleCancel = () => {
+    setMode(Mode.LIST);
+    if (tab === Tab.TEAMS) {
+      resetTeamForm();
+    } else {
+      resetParticipantForm();
+    }
+  };
+
+  const clearMessages = () => {
+    setError(null);
+    setSuccess(null);
+  };
+
+  const handleGoHome = () => navigate('/', { replace: true });
+
+  return {
+    tab,
+    setTab,
+    mode,
+    setMode,
+    batch,
+    setBatch,
+    teams,
+    participants,
+    selectedTeam,
+    selectedParticipant,
+    loading,
+    error,
+    success,
+    teamFilter,
+    setTeamFilter,
+    teamForm,
+    participantForm,
+    teamImage,
+    filteredParticipants,
+    handleCreateTeam,
+    handleUpdateTeam,
+    handleDeleteTeam,
+    handleCreateParticipant,
+    handleUpdateParticipant,
+    handleDeleteParticipant,
+    handleEditTeam,
+    handleEditParticipant,
+    handleTeamFormChange,
+    handleParticipantFormChange,
+    handleImageChange,
+    resetTeamForm,
+    resetParticipantForm,
+    startCreateMode,
+    handleCancel,
+    clearMessages,
+    setError,
+    setSuccess,
+    handleGoHome,
+  };
+};
+
+export default useSettingManager;

--- a/src/hooks/useTeamsData.ts
+++ b/src/hooks/useTeamsData.ts
@@ -1,0 +1,140 @@
+import { useState, useEffect } from 'react';
+import { teamService, participantService } from '../api';
+import { Team } from '../features/teams/types';
+import { Participant } from '../features/participants/types';
+
+const TEAM_ORDER = ['호랑이', '사자', '여우', '팬더', '곰', '늑대'];
+
+const useTeamsData = () => {
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [selectedTeam, setSelectedTeam] = useState<string | null>(null);
+  const [teamMembers, setTeamMembers] = useState<Participant[]>([]);
+  const [changeLoading, setChangeLoading] = useState<{ [key: string]: boolean }>(
+    {},
+  );
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [totalFirstBatchParticipants, setTotalFirstBatchParticipants] =
+    useState<number>(0);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+
+        const teamsData = await teamService.getAll();
+        if (teamsData && teamsData.length > 0) {
+          const activeTeams = teamsData.filter(team => team.is_active);
+
+          const sortedTeams = [...activeTeams].sort((a, b) => {
+            const indexA = TEAM_ORDER.indexOf(a.name);
+            const indexB = TEAM_ORDER.indexOf(b.name);
+
+            if (indexA === -1) return 1;
+            if (indexB === -1) return -1;
+
+            return indexA - indexB;
+          });
+
+          setTeams(sortedTeams);
+
+          if (!selectedTeam && sortedTeams.length > 0) {
+            setSelectedTeam(sortedTeams[0].name);
+          }
+
+          const participantsData = await participantService.getAll();
+          if (participantsData) {
+            const activeTeamNames = activeTeams.map(team => team.name);
+
+            const firstBatchParticipants = participantsData.filter(
+              p =>
+                p.batch === 1 &&
+                p.role === '참가자' &&
+                activeTeamNames.includes(p.team),
+            );
+            setTotalFirstBatchParticipants(firstBatchParticipants.length);
+
+            if (selectedTeam) {
+              const filteredMembers = participantsData.filter(
+                p => p.team === selectedTeam && p.batch === 1,
+              );
+              setTeamMembers(filteredMembers);
+            } else {
+              setTeamMembers([]);
+            }
+          }
+        } else {
+          setTeams([]);
+          setSelectedTeam(null);
+        }
+
+        setLoading(false);
+      } catch (err) {
+        console.error('데이터 로딩 중 오류 발생:', err);
+        setError(
+          err instanceof Error
+            ? err.message
+            : '데이터를 불러오는 중 오류가 발생했습니다.',
+        );
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [selectedTeam]);
+
+  const handleTeamSelect = (teamName: string) => {
+    setSelectedTeam(teamName);
+  };
+
+  const handleTeamChange = async (
+    participantId: string,
+    newTeam: string,
+    currentName: string,
+  ) => {
+    if (newTeam === selectedTeam) return;
+
+    try {
+      setChangeLoading(prev => ({ ...prev, [participantId]: true }));
+      setError(null);
+      setSuccessMessage(null);
+
+      const result = await participantService.update(participantId, {
+        team: newTeam,
+      });
+
+      if (result) {
+        setSuccessMessage(`${currentName}님이 ${newTeam} 팀으로 이동되었습니다.`);
+        setTeamMembers(prev => prev.filter(p => p.id !== participantId));
+        setTimeout(() => {
+          setSuccessMessage(null);
+        }, 3000);
+      } else {
+        setError('팀 변경에 실패했습니다.');
+      }
+    } catch (err) {
+      setError('오류가 발생했습니다.');
+      console.error(err);
+    } finally {
+      setChangeLoading(prev => ({ ...prev, [participantId]: false }));
+    }
+  };
+
+  return {
+    loading,
+    error,
+    teams,
+    selectedTeam,
+    teamMembers,
+    changeLoading,
+    successMessage,
+    totalFirstBatchParticipants,
+    handleTeamSelect,
+    handleTeamChange,
+    setError,
+    setSuccessMessage,
+  };
+};
+
+export default useTeamsData;

--- a/src/pages/join/index.tsx
+++ b/src/pages/join/index.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from 'react-router-dom';
 import bgImage from '../../assets/bg.webp';
 import heroImage from '../../assets/hero.gif';
 import MobileLayout from '../../shared/layouts/MobileLayout';
@@ -9,7 +8,6 @@ import useJoinFlow from '../../hooks/useJoinFlow';
 import keyframes from '../../styles/animations/keyframes';
 
 const RootPage = () => {
-  const navigate = useNavigate();
   const {
     step,
     name,

--- a/src/pages/join/index.tsx
+++ b/src/pages/join/index.tsx
@@ -1,255 +1,32 @@
-import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import bgImage from '../../assets/bg.webp';
 import heroImage from '../../assets/hero.gif';
-import Lottie, { LottieRefCurrentProps } from 'lottie-react';
-import congratsAnimation from '../../assets/congrats.json';
 import MobileLayout from '../../shared/layouts/MobileLayout';
 import { Loading, TextInput } from '../../shared/components';
-import useTypingText from '../../hooks/useTypingText';
-import useJoinQuestions from '../../hooks/useJoinQuestions';
-import { teamService, participantService } from '../../api';
-import { Team } from '../../features/teams/types';
-import { Participant, ParticipantCreate } from '../../features/participants/types';
+import Lottie from 'lottie-react';
+import congratsAnimation from '../../assets/congrats.json';
+import useJoinFlow from '../../hooks/useJoinFlow';
 import keyframes from '../../styles/animations/keyframes';
 
 const RootPage = () => {
   const navigate = useNavigate();
-  const [step, setStep] = useState(1);
-  const [name, setName] = useState('');
-  const [selections, setSelections] = useState<string[]>([]);
-  const { text: displayText, start: startTyping } = useTypingText();
-  const { getQuestionText, getOptions } = useJoinQuestions(name, selections);
-  const [isLoading, setIsLoading] = useState(false);
-  const [showSpark, setShowSpark] = useState(false);
-  const [teams, setTeams] = useState<Team[]>([]);
-  const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
-  const [isTeamsLoaded, setIsTeamsLoaded] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [isChecking, setIsChecking] = useState(false);
-  const currentStepRef = useRef<number>(1);
-  const congratsRef = useRef<LottieRefCurrentProps>(null);
-
-  useEffect(() => {
-    const savedParticipantId = localStorage.getItem('participantId');
-    if (savedParticipantId) {
-      checkSavedParticipant(savedParticipantId);
-    }
-  }, []);
-
-  const checkSavedParticipant = async (participantId: string) => {
-    try {
-      const participant = await participantService.getById(participantId);
-      if (participant) {
-        saveParticipantToLocalStorage(participant);
-        navigate('/main');
-      }
-    } catch (error) {
-      console.error('저장된 참가자 정보 확인 실패:', error);
-      localStorage.removeItem('participantId');
-    }
-  };
-
-  useEffect(() => {
-    const fetchTeams = async () => {
-      try {
-        const teamsData = await teamService.getByBatch(1);
-        if (teamsData && teamsData.length > 0) {
-          setTeams(teamsData);
-          setIsTeamsLoaded(true);
-        } else {
-          console.error('팀 데이터가 없습니다.');
-        }
-      } catch (error) {
-        console.error('팀 데이터 로딩 중 오류 발생:', error);
-      }
-    };
-
-    fetchTeams();
-  }, []);
-
-  const checkNameExists = async (name: string) => {
-    if (!name.trim()) return false;
-
-    try {
-      setIsChecking(true);
-      const participants = await participantService.getByName(name.trim());
-      setIsChecking(false);
-
-      if (participants && participants.length > 0) {
-        saveParticipantToLocalStorage(participants[0]);
-        navigate('/main');
-        return true;
-      }
-      return false;
-    } catch (error) {
-      console.error('이름 중복 확인 중 오류 발생:', error);
-      setIsChecking(false);
-      return false;
-    }
-  };
-
-  const saveParticipantToLocalStorage = (participant: Participant) => {
-    localStorage.setItem('participantId', participant.id);
-    localStorage.setItem('participantName', participant.name);
-    localStorage.setItem('participantTeam', participant.team);
-    localStorage.setItem('participantRole', participant.role);
-    localStorage.setItem('participantBatch', participant.batch.toString());
-  };
-
-  const handleNext = () => {
-    if (step === 3) {
-      setIsLoading(true);
-
-      setTimeout(() => {
-        setShowSpark(true);
-
-        setTimeout(() => {
-          setShowSpark(false);
-          setIsLoading(false);
-          const nextStep = step + 1;
-          currentStepRef.current = nextStep;
-          setStep(nextStep);
-
-          setTimeout(() => {
-            startTypingAnimation();
-          }, 100);
-        }, 500);
-      }, 5000);
-
-      return;
-    }
-
-    const nextStep = step + 1;
-    currentStepRef.current = nextStep;
-    setStep(nextStep);
-
-    setTimeout(() => {
-      startTypingAnimation();
-    }, 100);
-  };
-
-  const selectLeastPopulatedTeam = async () => {
-    try {
-      if (!isTeamsLoaded || teams.length === 0) {
-        console.error('팀 데이터가 로드되지 않았습니다.');
-        return null;
-      }
-
-      const teamCounts = await participantService.getTeamCounts(1);
-      if (!teamCounts) {
-        console.error('팀별 참가자 수를 가져오는 데 실패했습니다.');
-        return teams[Math.floor(Math.random() * teams.length)];
-      }
-
-      const teamsWithCounts = teams.map(team => ({
-        ...team,
-        count: teamCounts[team.name] || 0,
-      }));
-
-      const minCount = Math.min(...teamsWithCounts.map(t => t.count));
-      const leastPopulatedTeams = teamsWithCounts.filter(t => t.count === minCount);
-
-      const selectedTeam =
-        leastPopulatedTeams[Math.floor(Math.random() * leastPopulatedTeams.length)];
-
-      return selectedTeam;
-    } catch (error) {
-      console.error('팀 선택 중 오류 발생:', error);
-      return teams[Math.floor(Math.random() * teams.length)];
-    }
-  };
-
-  const createParticipant = async (team: Team) => {
-    try {
-      if (!name.trim()) {
-        console.error('참가자 이름이 없습니다.');
-        return false;
-      }
-
-      const newParticipant: ParticipantCreate = {
-        name: name.trim(),
-        team: team.name,
-        role: '참가자',
-        batch: 1,
-      };
-
-      const result = await participantService.create(newParticipant);
-      if (result && result.length > 0) {
-        saveParticipantToLocalStorage(result[0]);
-        return true;
-      } else {
-        console.error('참가자 생성 실패');
-        return false;
-      }
-    } catch (error) {
-      console.error('참가자 생성 중 오류 발생:', error);
-      return false;
-    }
-  };
-
-  const handleSelection = (option: string) => {
-    setSelections(prev => [...prev, option]);
-
-    if (step === 3) {
-      if (isTeamsLoaded && teams.length > 0) {
-        selectLeastPopulatedTeam().then(team => {
-          if (team) {
-            setSelectedTeam(team);
-            createParticipant(team).then(success => {
-              if (!success) {
-                setError('참가자 정보를 저장하는데 실패했습니다.');
-              }
-            });
-          } else {
-            console.error('팀 선택에 실패했습니다.');
-          }
-        });
-      } else {
-        console.error('팀 데이터가 로드되지 않았습니다.');
-      }
-    }
-
-    handleNext();
-  };
-
-  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setName(e.target.value);
-  };
-
-  const handleNameSubmit = async () => {
-    if (!name.trim()) return;
-
-    const nameExists = await checkNameExists(name);
-
-    if (!nameExists) {
-      handleNext();
-    }
-  };
-
-  const startTypingAnimation = () => {
-    startTyping(getQuestionText(currentStepRef.current));
-  };
-
-  useEffect(() => {
-    currentStepRef.current = step;
-  }, [step]);
-
-  useEffect(() => {
-    startTypingAnimation();
-  }, []);
-
-  useEffect(() => {
-    if (step === 2) {
-      startTypingAnimation();
-    }
-  }, [name, step]);
-
-  useEffect(() => {
-    if (congratsRef.current) {
-      congratsRef.current.setSpeed(0.5);
-    }
-  }, [step]);
+  const {
+    step,
+    name,
+    selections,
+    displayText,
+    getOptions,
+    isLoading,
+    showSpark,
+    selectedTeam,
+    error,
+    isChecking,
+    congratsRef,
+    handleNameChange,
+    handleNameSubmit,
+    handleSelection,
+    handleCompleteClick,
+  } = useJoinFlow();
 
   const renderContent = () => {
     if (isLoading) {
@@ -384,10 +161,6 @@ const RootPage = () => {
       default:
         return null;
     }
-  };
-
-  const handleCompleteClick = () => {
-    navigate('/main');
   };
 
   return (

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -1,68 +1,18 @@
-import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import MobileLayout from '../../shared/layouts/MobileLayout';
-import { teamService, participantService } from '../../api';
-import { Team } from '../../features/teams/types';
-import { Participant } from '../../features/participants/types';
 import keyframes from '../../styles/animations/keyframes';
+import useMainData from '../../hooks/useMainData';
 
 const MainPage = () => {
   const navigate = useNavigate();
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-  const [team, setTeam] = useState<Team | null>(null);
-  const [teamMembers, setTeamMembers] = useState<Participant[]>([]);
-  const [currentParticipant, setCurrentParticipant] = useState<Participant | null>(null);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const participantId = localStorage.getItem('participantId');
-        const participantTeam = localStorage.getItem('participantTeam');
-
-        if (!participantId || !participantTeam) {
-          navigate('/join');
-          return;
-        }
-
-        const participant = await participantService.getById(participantId);
-        if (!participant) {
-          throw new Error('참가자 정보를 찾을 수 없습니다.');
-        }
-        setCurrentParticipant(participant);
-
-        const teams = await teamService.getByName(participantTeam);
-        if (!teams) {
-          throw new Error('팀 정보를 찾을 수 없습니다.');
-        }
-        setTeam(teams);
-
-        const batch = participant.batch;
-        const allParticipants = await participantService.getByBatch(batch);
-        if (allParticipants) {
-          const sameTeamMembers = allParticipants.filter(p => p.team === participantTeam);
-          setTeamMembers(sameTeamMembers);
-        }
-
-        setLoading(false);
-      } catch (err) {
-        console.error('데이터 로딩 중 오류 발생:', err);
-        setError(err instanceof Error ? err.message : '데이터를 불러오는 중 오류가 발생했습니다.');
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [navigate]);
-
-  const handleLeaveTeam = () => {
-    localStorage.removeItem('participantId');
-    localStorage.removeItem('participantName');
-    localStorage.removeItem('participantTeam');
-    localStorage.removeItem('participantRole');
-    localStorage.removeItem('participantBatch');
-    navigate('/');
-  };
+  const {
+    loading,
+    error,
+    team,
+    teamMembers,
+    currentParticipant,
+    handleLeaveTeam,
+  } = useMainData();
 
   if (loading) {
     return (

--- a/src/pages/setting/index.tsx
+++ b/src/pages/setting/index.tsx
@@ -10,9 +10,6 @@ const SettingPage = () => {
     batch,
     setBatch,
     teams,
-    participants,
-    selectedTeam,
-    selectedParticipant,
     loading,
     error,
     success,
@@ -33,16 +30,16 @@ const SettingPage = () => {
     handleTeamFormChange,
     handleParticipantFormChange,
     handleImageChange,
-    resetTeamForm,
-    resetParticipantForm,
     startCreateMode,
     handleCancel,
     clearMessages,
     setError,
     setSuccess,
     handleGoHome,
+    setTeamForm,
   } = useSettingManager();
 
+  return (
     <MobileLayout>
       <div className="p-4">
         <div className="flex items-center mb-4">
@@ -251,14 +248,12 @@ const SettingPage = () => {
                       onChange={e => setTeamFilter(e.target.value)}
                       className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
                     >
-                      <option value="전체">전체 팀</option>
-                      {teams
-                        .filter(team => team.is_active)
-                        .map(team => (
-                          <option key={team.id} value={team.name}>
-                            {team.name}
-                          </option>
-                        ))}
+                      <option value="전체">전체</option>
+                      {teams.map(team => (
+                        <option key={team.id} value={team.name}>
+                          {team.name}
+                        </option>
+                      ))}
                     </select>
                   </div>
 
@@ -273,6 +268,9 @@ const SettingPage = () => {
                             팀
                           </th>
                           <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                            역할
+                          </th>
+                          <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                             작업
                           </th>
                         </tr>
@@ -281,10 +279,11 @@ const SettingPage = () => {
                         {filteredParticipants.length > 0 ? (
                           filteredParticipants.map(participant => (
                             <tr key={participant.id}>
-                              <td className="px-6 py-4 whitespace-nowrap font-medium">
-                                {participant.name}
+                              <td className="px-6 py-4 whitespace-nowrap">
+                                <span className="font-medium">{participant.name}</span>
                               </td>
                               <td className="px-6 py-4 whitespace-nowrap">{participant.team}</td>
+                              <td className="px-6 py-4 whitespace-nowrap">{participant.role}</td>
                               <td className="px-6 py-4 whitespace-nowrap">
                                 <div className="flex gap-2">
                                   <button
@@ -305,10 +304,7 @@ const SettingPage = () => {
                           ))
                         ) : (
                           <tr>
-                            <td
-                              colSpan={3}
-                              className="px-6 py-8 text-center text-gray-500 align-top"
-                            >
+                            <td colSpan={4} className="px-6 py-8 text-center text-gray-500 align-top">
                               <div className="flex flex-col items-center">
                                 <svg
                                   xmlns="http://www.w3.org/2000/svg"
@@ -324,11 +320,7 @@ const SettingPage = () => {
                                     d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
                                   />
                                 </svg>
-                                <p className="font-medium">
-                                  {teamFilter === '전체'
-                                    ? '데이터가 없습니다'
-                                    : `${teamFilter} 팀의 참가자가 없습니다`}
-                                </p>
+                                <p className="font-medium">데이터가 없습니다</p>
                                 <p className="text-sm mt-1">새 항목을 추가해 보세요</p>
                               </div>
                             </td>
@@ -354,7 +346,7 @@ const SettingPage = () => {
                 className="space-y-6"
               >
                 <div>
-                  <label className="block mb-2 font-medium">팀 이름 *</label>
+                  <label className="block mb-2 font-medium">이름 *</label>
                   <input
                     type="text"
                     name="name"

--- a/src/pages/setting/index.tsx
+++ b/src/pages/setting/index.tsx
@@ -1,407 +1,54 @@
-import React, { useState, useEffect } from 'react';
-import { participantService, teamService, storageService } from '../../api';
-import { Participant, ParticipantCreate } from '../../features/participants/types';
-import { Team, TeamCreate } from '../../features/teams/types';
 import MobileLayout from '../../shared/layouts/MobileLayout';
-import { useNavigate } from 'react-router-dom';
-
-enum Tab {
-  TEAMS = 'teams',
-  PARTICIPANTS = 'participants',
-}
-
-enum Mode {
-  LIST = 'list',
-  CREATE = 'create',
-  EDIT = 'edit',
-}
+import useSettingManager, { Tab, Mode } from '../../hooks/useSettingManager';
 
 const SettingPage = () => {
-  const navigate = useNavigate();
-  const [tab, setTab] = useState<Tab>(Tab.TEAMS);
-  const [mode, setMode] = useState<Mode>(Mode.LIST);
-  const [batch, setBatch] = useState<number>(1);
-  const [teams, setTeams] = useState<Team[]>([]);
-  const [participants, setParticipants] = useState<Participant[]>([]);
-  const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
-  const [selectedParticipant, setSelectedParticipant] = useState<Participant | null>(null);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState<string | null>(null);
-  const [teamFilter, setTeamFilter] = useState<string>('전체');
+  const {
+    tab,
+    setTab,
+    mode,
+    setMode,
+    batch,
+    setBatch,
+    teams,
+    participants,
+    selectedTeam,
+    selectedParticipant,
+    loading,
+    error,
+    success,
+    teamFilter,
+    setTeamFilter,
+    teamForm,
+    participantForm,
+    teamImage,
+    filteredParticipants,
+    handleCreateTeam,
+    handleUpdateTeam,
+    handleDeleteTeam,
+    handleCreateParticipant,
+    handleUpdateParticipant,
+    handleDeleteParticipant,
+    handleEditTeam,
+    handleEditParticipant,
+    handleTeamFormChange,
+    handleParticipantFormChange,
+    handleImageChange,
+    resetTeamForm,
+    resetParticipantForm,
+    startCreateMode,
+    handleCancel,
+    clearMessages,
+    setError,
+    setSuccess,
+    handleGoHome,
+  } = useSettingManager();
 
-  const [teamForm, setTeamForm] = useState<Partial<TeamCreate>>({
-    name: '',
-    description: '',
-    characteristic: '',
-    image_url: '',
-    is_active: true,
-    batch: 1,
-  });
-
-  const [participantForm, setParticipantForm] = useState<Partial<ParticipantCreate>>({
-    name: '',
-    team: '',
-    role: '',
-    batch: 1,
-  });
-
-  const [teamImage, setTeamImage] = useState<File | null>(null);
-
-  useEffect(() => {
-    fetchTeams();
-    fetchParticipants();
-  }, [batch]);
-
-  const fetchTeams = async () => {
-    try {
-      setLoading(true);
-
-      const result = await teamService.getAllByBatch(batch);
-      if (result) {
-        setTeams(result);
-      } else {
-        setError('팀 데이터를 불러오는데 실패했습니다.');
-      }
-    } catch (err) {
-      setError('오류가 발생했습니다.');
-      console.error(err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const fetchParticipants = async () => {
-    try {
-      setLoading(true);
-      const result = await participantService.getByBatch(batch);
-      if (result) {
-        setParticipants(result);
-      } else {
-        setError('참가자 데이터를 불러오는데 실패했습니다.');
-      }
-    } catch (err) {
-      setError('오류가 발생했습니다.');
-      console.error(err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const filteredParticipants =
-    teamFilter === '전체' ? participants : participants.filter(p => p.team === teamFilter);
-
-  const handleCreateTeam = async (e: React.FormEvent) => {
-    e.preventDefault();
-    try {
-      setLoading(true);
-      setError(null);
-
-      let imageUrl = teamForm.image_url;
-
-      if (teamImage) {
-        const path = `teams/${Date.now()}_${teamImage.name}`;
-        const uploadedUrl = await storageService.uploadImage(teamImage, path);
-        if (uploadedUrl) {
-          imageUrl = uploadedUrl;
-        } else {
-          setError('이미지 업로드에 실패했습니다.');
-          setLoading(false);
-          return;
-        }
-      }
-
-      const newTeam: TeamCreate = {
-        name: teamForm.name || '',
-        description: teamForm.description || '',
-        characteristic: teamForm.characteristic || '',
-        image_url: imageUrl || '',
-        is_active: teamForm.is_active !== undefined ? teamForm.is_active : true,
-        batch: teamForm.batch || batch,
-      };
-
-      const result = await teamService.create(newTeam);
-      if (result) {
-        setSuccess('팀이 성공적으로 생성되었습니다.');
-        setMode(Mode.LIST);
-        fetchTeams();
-        resetTeamForm();
-      } else {
-        setError('팀 생성에 실패했습니다.');
-      }
-    } catch (err) {
-      setError('오류가 발생했습니다.');
-      console.error(err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleUpdateTeam = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!selectedTeam) return;
-
-    try {
-      setLoading(true);
-      setError(null);
-
-      let imageUrl = teamForm.image_url;
-
-      if (teamImage) {
-        const path = `teams/${Date.now()}_${teamImage.name}`;
-        const uploadedUrl = await storageService.uploadImage(teamImage, path);
-        if (uploadedUrl) {
-          imageUrl = uploadedUrl;
-        } else {
-          setError('이미지 업로드에 실패했습니다.');
-          setLoading(false);
-          return;
-        }
-      }
-
-      const updatedTeam: Partial<TeamCreate> = {
-        name: teamForm.name,
-        description: teamForm.description,
-        characteristic: teamForm.characteristic,
-        is_active: teamForm.is_active,
-        batch: teamForm.batch,
-      };
-
-      if (imageUrl && imageUrl !== selectedTeam.image_url) {
-        updatedTeam.image_url = imageUrl;
-      }
-
-      const result = await teamService.update(selectedTeam.id, updatedTeam);
-      if (result) {
-        setSuccess('팀이 성공적으로 수정되었습니다.');
-        setMode(Mode.LIST);
-        fetchTeams();
-        resetTeamForm();
-      } else {
-        setError('팀 수정에 실패했습니다.');
-      }
-    } catch (err) {
-      setError('오류가 발생했습니다.');
-      console.error(err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleDeleteTeam = async (id: string) => {
-    if (!window.confirm('정말로 이 팀을 삭제하시겠습니까?')) return;
-
-    try {
-      setLoading(true);
-      setError(null);
-
-      const success = await teamService.delete(id);
-      if (success) {
-        setSuccess('팀이 성공적으로 삭제되었습니다.');
-        fetchTeams();
-      } else {
-        setError('팀 삭제에 실패했습니다.');
-      }
-    } catch (err) {
-      setError('오류가 발생했습니다.');
-      console.error(err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleCreateParticipant = async (e: React.FormEvent) => {
-    e.preventDefault();
-    try {
-      setLoading(true);
-      setError(null);
-
-      const newParticipant: ParticipantCreate = {
-        name: participantForm.name || '',
-        team: participantForm.team || '',
-        role: participantForm.role || '',
-        batch: participantForm.batch || batch,
-      };
-
-      const result = await participantService.create(newParticipant);
-      if (result) {
-        setSuccess('참가자가 성공적으로 생성되었습니다.');
-        setMode(Mode.LIST);
-        fetchParticipants();
-        resetParticipantForm();
-      } else {
-        setError('참가자 생성에 실패했습니다.');
-      }
-    } catch (err) {
-      setError('오류가 발생했습니다.');
-      console.error(err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleUpdateParticipant = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!selectedParticipant) return;
-
-    try {
-      setLoading(true);
-      setError(null);
-
-      const updatedParticipant: Partial<ParticipantCreate> = {
-        name: participantForm.name,
-        team: participantForm.team,
-        role: participantForm.role,
-        batch: participantForm.batch,
-      };
-
-      const result = await participantService.update(selectedParticipant.id, updatedParticipant);
-      if (result) {
-        setSuccess('참가자가 성공적으로 수정되었습니다.');
-        setMode(Mode.LIST);
-        fetchParticipants();
-        resetParticipantForm();
-      } else {
-        setError('참가자 수정에 실패했습니다.');
-      }
-    } catch (err) {
-      setError('오류가 발생했습니다.');
-      console.error(err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleDeleteParticipant = async (id: string) => {
-    if (!window.confirm('정말로 이 참가자를 삭제하시겠습니까?')) return;
-
-    try {
-      setLoading(true);
-      setError(null);
-
-      const success = await participantService.delete(id);
-      if (success) {
-        setSuccess('참가자가 성공적으로 삭제되었습니다.');
-        fetchParticipants();
-      } else {
-        setError('참가자 삭제에 실패했습니다.');
-      }
-    } catch (err) {
-      setError('오류가 발생했습니다.');
-      console.error(err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleEditTeam = (team: Team) => {
-    setSelectedTeam(team);
-    setTeamForm({
-      name: team.name,
-      description: team.description,
-      characteristic: team.characteristic,
-      image_url: team.image_url,
-      is_active: team.is_active,
-      batch: team.batch,
-    });
-    setMode(Mode.EDIT);
-  };
-
-  const handleEditParticipant = (participant: Participant) => {
-    setSelectedParticipant(participant);
-    setParticipantForm({
-      name: participant.name,
-      team: participant.team,
-      role: participant.role,
-      batch: participant.batch,
-    });
-    setMode(Mode.EDIT);
-  };
-
-  const handleTeamFormChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
-  ) => {
-    const { name, value, type } = e.target;
-    if (type === 'checkbox') {
-      const checked = (e.target as HTMLInputElement).checked;
-      setTeamForm(prev => ({ ...prev, [name]: checked }));
-    } else if (name === 'batch') {
-      setTeamForm(prev => ({ ...prev, [name]: parseInt(value) }));
-    } else {
-      setTeamForm(prev => ({ ...prev, [name]: value }));
-    }
-  };
-
-  const handleParticipantFormChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
-  ) => {
-    const { name, value } = e.target;
-    if (name === 'batch') {
-      setParticipantForm(prev => ({ ...prev, [name]: parseInt(value) }));
-    } else {
-      setParticipantForm(prev => ({ ...prev, [name]: value }));
-    }
-  };
-
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files && e.target.files.length > 0) {
-      setTeamImage(e.target.files[0]);
-    }
-  };
-
-  const resetTeamForm = () => {
-    setTeamForm({
-      name: '',
-      description: '',
-      characteristic: '',
-      image_url: '',
-      is_active: true,
-      batch: batch,
-    });
-    setTeamImage(null);
-    setSelectedTeam(null);
-  };
-
-  const resetParticipantForm = () => {
-    setParticipantForm({
-      name: '',
-      team: '',
-      role: '',
-      batch: batch,
-    });
-    setSelectedParticipant(null);
-  };
-
-  const startCreateMode = () => {
-    if (tab === Tab.TEAMS) {
-      resetTeamForm();
-    } else {
-      resetParticipantForm();
-    }
-    setMode(Mode.CREATE);
-  };
-
-  const handleCancel = () => {
-    setMode(Mode.LIST);
-    if (tab === Tab.TEAMS) {
-      resetTeamForm();
-    } else {
-      resetParticipantForm();
-    }
-  };
-
-  const clearMessages = () => {
-    setError(null);
-    setSuccess(null);
-  };
-
-  return (
     <MobileLayout>
       <div className="p-4">
         <div className="flex items-center mb-4">
           <button
             className="mr-2 p-2 rounded-full hover:bg-gray-100"
-            onClick={() => navigate('/', { replace: true })}
+            onClick={handleGoHome}
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/teams/index.tsx
+++ b/src/pages/teams/index.tsx
@@ -2,8 +2,6 @@ import MobileLayout from '../../shared/layouts/MobileLayout';
 import { useNavigate } from 'react-router-dom';
 import useTeamsData from '../../hooks/useTeamsData';
 
-const TEAM_ORDER = ['호랑이', '사자', '여우', '팬더', '곰', '늑대'];
-
 const TeamsPage = () => {
   const navigate = useNavigate();
   const {

--- a/src/pages/teams/index.tsx
+++ b/src/pages/teams/index.tsx
@@ -1,115 +1,25 @@
-import { useState, useEffect } from 'react';
 import MobileLayout from '../../shared/layouts/MobileLayout';
-import { teamService, participantService } from '../../api';
-import { Team } from '../../features/teams/types';
-import { Participant } from '../../features/participants/types';
 import { useNavigate } from 'react-router-dom';
+import useTeamsData from '../../hooks/useTeamsData';
 
 const TEAM_ORDER = ['호랑이', '사자', '여우', '팬더', '곰', '늑대'];
 
 const TeamsPage = () => {
   const navigate = useNavigate();
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-  const [teams, setTeams] = useState<Team[]>([]);
-  const [selectedTeam, setSelectedTeam] = useState<string | null>(null);
-  const [teamMembers, setTeamMembers] = useState<Participant[]>([]);
-  const [changeLoading, setChangeLoading] = useState<{ [key: string]: boolean }>({});
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
-  const [totalFirstBatchParticipants, setTotalFirstBatchParticipants] = useState<number>(0);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        setLoading(true);
-
-        const teamsData = await teamService.getAll();
-        if (teamsData && teamsData.length > 0) {
-          const activeTeams = teamsData.filter(team => team.is_active);
-          
-          const sortedTeams = [...activeTeams].sort((a, b) => {
-            const indexA = TEAM_ORDER.indexOf(a.name);
-            const indexB = TEAM_ORDER.indexOf(b.name);
-            
-            if (indexA === -1) return 1;
-            if (indexB === -1) return -1;
-            
-            return indexA - indexB;
-          });
-          
-          setTeams(sortedTeams);
-          
-          if (!selectedTeam && sortedTeams.length > 0) {
-            setSelectedTeam(sortedTeams[0].name);
-          }
-          
-          const participantsData = await participantService.getAll();
-          if (participantsData) {
-            // 활성화된 팀 이름 목록
-            const activeTeamNames = activeTeams.map(team => team.name);
-            
-            // 1기 참가자 중 활성화된 팀에 속한 참가자만 필터링
-            const firstBatchParticipants = participantsData.filter(
-              p => p.batch === 1 && 
-                   p.role === '참가자' && 
-                   activeTeamNames.includes(p.team)
-            );
-            setTotalFirstBatchParticipants(firstBatchParticipants.length);
-            
-            if (selectedTeam) {
-              const filteredMembers = participantsData.filter(
-                p => p.team === selectedTeam && p.batch === 1
-              );
-              setTeamMembers(filteredMembers);
-            } else {
-              setTeamMembers([]);
-            }
-          }
-        } else {
-          setTeams([]);
-          setSelectedTeam(null);
-        }
-
-        setLoading(false);
-      } catch (err) {
-        console.error('데이터 로딩 중 오류 발생:', err);
-        setError(err instanceof Error ? err.message : '데이터를 불러오는 중 오류가 발생했습니다.');
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [selectedTeam]);
-
-  const handleTeamSelect = (teamName: string) => {
-    setSelectedTeam(teamName);
-  };
-  const handleTeamChange = async (participantId: string, newTeam: string, currentName: string) => {
-    if (newTeam === selectedTeam) return;
-
-    try {
-      setChangeLoading(prev => ({ ...prev, [participantId]: true }));
-      setError(null);
-      setSuccessMessage(null);
-
-      const result = await participantService.update(participantId, { team: newTeam });
-
-      if (result) {
-        setSuccessMessage(`${currentName}님이 ${newTeam} 팀으로 이동되었습니다.`);
-        setTeamMembers(prev => prev.filter(p => p.id !== participantId));
-        setTimeout(() => {
-          setSuccessMessage(null);
-        }, 3000);
-      } else {
-        setError('팀 변경에 실패했습니다.');
-      }
-    } catch (err) {
-      setError('오류가 발생했습니다.');
-      console.error(err);
-    } finally {
-      setChangeLoading(prev => ({ ...prev, [participantId]: false }));
-    }
-  };
+  const {
+    loading,
+    error,
+    teams,
+    selectedTeam,
+    teamMembers,
+    changeLoading,
+    successMessage,
+    totalFirstBatchParticipants,
+    handleTeamSelect,
+    handleTeamChange,
+    setError,
+    setSuccessMessage,
+  } = useTeamsData();
 
   return (
     <MobileLayout>


### PR DESCRIPTION
## Summary
- extract data logic from main, join, setting, and teams pages into reusable hooks
- update pages to consume the new hooks for clearer separation of concerns

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*